### PR TITLE
Add support for BackBit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,19 +30,21 @@ export LD65_LIB=/opt/cc65/share/cc65/lib
 .SUFFIXES: .prg .s .c
 .PHONY: clean subdirs all easyflash mrproper
 
-LOADER_FILES=build/ef/menu.o build/ef/loader.o build/ef/io-data.o build/ef/io-rw.o build/ef/io-code.o build/exo/exodecrunch.o build/ef/menu_savegame.o build/ef/menu_util.o build/ef/menu_backup.o build/ef/music-base.o build/ef/music-disassemble.o
-
-MUSIC_FILES=build/ef/music-base.o build/ef/music-disassemble.o
+EF_LOADER_FILES=build/ef/menu.o build/ef/loader.o build/ef/io-data.o build/ef/io-rw.o build/ef/io-code.o build/exo/exodecrunch.o build/ef/menu_savegame.o build/ef/menu_util.o build/ef/menu_backup.o build/ef/music-base.o build/ef/music-disassemble.o
+EF_MUSIC_FILES=build/ef/music-base.o build/ef/music-disassemble.o
 
 
 # all
-all: easyflash d81
+all: easyflash d81 backbit
 
 # easyflash
 easyflash: subdirs build/ef/directory.data.prg build/ef/files.data.prg build/u5remastered.crt
 
 # d81
 d81: subdirs build/u5remastered.d81
+
+# backbit
+backbit: subdirs build/u5remastered-BackBit.d81
 
 # assemble
 build/%.o: src/%.s
@@ -69,12 +71,12 @@ build/ef/init.prg: build/ef/init.o
 	$(LD65) $(LD65FLAGS) -o $@ -C src/ef/init.cfg $^
 
 # easyflash loader.prg
-build/ef/loader.prg: $(LOADER_FILES)
-	$(LD65) $(LD65FLAGS) -vm -m ./build/ef/loader.map -o $@ -C src/ef/loader.cfg c64.lib $(LOADER_FILES)
+build/ef/loader.prg: $(EF_LOADER_FILES)
+	$(LD65) $(LD65FLAGS) -vm -m ./build/ef/loader.map -o $@ -C src/ef/loader.cfg c64.lib $(EF_LOADER_FILES)
 
 # music
-build/ef/music.prg build/ef.f/music_rom.bin build/ef/music.map: $(MUSIC_FILES)
-	$(LD65) $(LD65FLAGS) -vm -m ./build/ef/music.map -o build/ef/music.prg -C src/ef/music.cfg $(MUSIC_FILES)
+build/ef/music.prg build/ef.f/music_rom.bin build/ef/music.map: $(EF_MUSIC_FILES)
+	$(LD65) $(LD65FLAGS) -vm -m ./build/ef/music.map -o build/ef/music.prg -C src/ef/music.cfg $(EF_MUSIC_FILES)
 
 # io-replacement
 build/ef/io-replacement.prg build/ef/io-replacement.map: build/ef/io-code.o build/ef/io-data.o build/ef/io-rw.o build/exo/exodecrunch.o
@@ -172,12 +174,52 @@ build/u5remastered.d81: build/d81.f/crunched.done build/d81.f/loader.prg build/d
 	tools/mkd81.py -v -o ./build/u5remastered.d81 -x ./src/d81/exclude.cfg -i ./src/d81/io.i -d ./src/disks.cfg -f ./build/d81.f
 
 # ------------------------------------------------------------------------
+# backbit
+
+# io-replacement d81
+build/backbit/io-replacement.prg build/backbit/io-replacement.map: build/backbit/io-code.o build/exo/exodecrunch.o
+	$(LD65) $(LD65FLAGS) -vm -m ./build/backbit/io-replacement.map -o build/backbit/io-replacement.prg -C ./src/backbit/io-replacement.cfg $^
+
+# loader
+build/backbit/loader.prg: build/backbit/loader.o
+	$(LD65) $(LD65FLAGS) -vm -m ./build/backbit/loader.map -o build/backbit/loader.prg -C ./src/backbit/loader.cfg $^
+
+build/backbit.f/loader.prg: build/backbit/loader.prg
+	cp ./build/backbit/loader.prg build/backbit.f/loader.prg
+
+build/backbit/exodecrunch.prg: build/exo/exodecrunch.o build/backbit/io-code.o
+	$(LD65) $(LD65FLAGS) -o $@ -C ./src/backbit/exodecrunch.cfg $^
+
+build/backbit.f/exodecrunch.prg: build/backbit/exodecrunch.prg
+	cp ./build/backbit/exodecrunch.prg ./build/backbit.f/exodecrunch.prg
+
+# files with additional items
+build/backbit.f/files.list: build/source/files.list
+	cp ./build/source/* ./build/backbit.f/
+
+# crunch
+build/backbit.f/crunched.done: build/backbit.f/patched.done
+	tools/crunch.py -v -t mem -b ./build/backbit.f
+	touch build/backbit.f/crunched.done
+
+# patch
+build/backbit.f/patched.done: build/backbit.f/files.list build/backbit/io-replacement.map build/backbit/io-replacement.prg
+	tools/u5patch.py -v -l ./build/backbit.f/files.list -f ./build/backbit.f -m build/backbit/io-replacement.map ./patches/backbit/*.patch ./patches/d81/*.patch ./patches/*.patch
+	touch ./build/backbit.f/patched.done
+
+# build disk
+build/u5remastered-BackBit.d81: build/backbit.f/crunched.done build/backbit.f/loader.prg build/backbit.f/exodecrunch.prg
+	tools/mkd81.py -v -o ./build/u5remastered-BackBit.d81 -x ./src/backbit/exclude.cfg -i ./src/backbit/io.i -d ./src/disks.cfg -f ./build/backbit.f
+
+# ------------------------------------------------------------------------
 
 subdirs:
 	@mkdir -p ./build/temp 
 	@mkdir -p ./build/exo
 	@mkdir -p ./build/d81.f
 	@mkdir -p ./build/d81
+	@mkdir -p ./build/backbit.f
+	@mkdir -p ./build/backbit
 	@mkdir -p ./build/source
 	@mkdir -p ./build/ef.f
 	@mkdir -p ./build/ef
@@ -185,12 +227,15 @@ subdirs:
 clean:
 	rm -rf build/ef
 	rm -rf build/d81
+	rm -rf build/backbit
 	rm -rf build/ef.f 
 	rm -rf build/d81.f
+	rm -rf build/backbit.f
 	rm -rf build/temp
 	rm -rf build/exo
 	rm -f build/u5remastered.crt
 	rm -f build/u5remastered.d81
+	rm -f build/u5remastered-BackBit.d81
 
 mrproper:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Ultima V Remastered
-This is the source to build an EasyFlash and 1581 version from original C64 
-Ultima V disks.
+This is the source to build an EasyFlash, 1581 or BackBit version from original C64 Ultima V disks.
 
 ## Features
 * Import and export save games

--- a/patches/backbit/meow.patch
+++ b/patches/backbit/meow.patch
@@ -1,0 +1,7 @@
+type = hex
+; don't override vectors
+filename = "0x41/meow"
+offset = 2
+address = 0x0012
+original = 208aff
+new      = eaeaea

--- a/src/backbit/exclude.cfg
+++ b/src/backbit/exclude.cfg
@@ -1,0 +1,18 @@
+osi meow
+osi u5siz.o
+osi dconfig
+britannia prty.data
+britannia roster
+britannia list
+britannia tlist
+britannia slist
+osi scratch
+osi subs.128
+osi xyzzy
+underworld tlist
+osi ultima v dox
+osi ultima 5 runes
+osi ultima v
+osi m
+osi temp.subs
+osi exo

--- a/src/backbit/exodecrunch.cfg
+++ b/src/backbit/exodecrunch.cfg
@@ -1,0 +1,38 @@
+# ----------------------------------------------------------------------------
+# Copyright 2019 Drunella
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+FEATURES {
+    STARTADDRESS:    default = $7c00;
+}
+
+SYMBOLS {
+    __LOADADDR__:    type = import;
+}
+
+MEMORY {
+    LOADADDR:        file = %O, start = %S - 2, size = $0002;
+    EXO_RAM:         start = $7c00,  size = $0100,  fill = no;
+
+    IO_REPLACEMENT:  start = $6c49,  size = $0265,  file = "";
+}
+
+SEGMENTS {
+    LOADADDR: load = LOADADDR, type = ro;
+    EXO_CODE: load = EXO_RAM,  type = rw,  define = yes;
+
+    IO_CODE:  load = IO_REPLACEMENT,  type = rw;
+    IO_DATA:  load = IO_REPLACEMENT,  type = rw;
+}

--- a/src/backbit/io-code.s
+++ b/src/backbit/io-code.s
@@ -1,0 +1,521 @@
+; ----------------------------------------------------------------------------
+; Copyright 2019 Drunella
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+; ----------------------------------------------------------------------------
+
+.include "io.i"
+
+; jump table vectors must be changed via patch
+;
+; 6c09: IO_request_disk_id
+;     param:
+;        A: requested disk id in range 0x01 to 0x08
+;     return:
+;        C set: disk not inserted
+;        C clear: disk inserted
+;
+; 6c2a: IO_request_disk_char
+;     param:
+;        A: requested disk id in range 0x41 to 0x48
+;     return:
+;        C set: disk not inserted
+;        C clear: disk inserted
+;
+; 6c24: IO_load_file
+;    param:
+;        filename: after return address, null terminated
+;        x: 0=return; x=1 jmp 0x0800; x>1 jmp 0xa700
+;    return:
+;        none
+;
+; 6c2d: IO_save_file
+;    saves a file. parameter list, deletes the file and saves it then
+;    param:
+;        X: unknown
+;        string: (after return address) null terminated filename, prepended with "S:"
+;        word: (after return address) address
+;        word: (after return address) size
+;    return:
+;        none
+;
+; 6c00: IO_read_block
+;     param:
+;         Y: track of disk
+;         X: sector of disk
+;         A: destination high address
+;     return:
+;         none
+;
+; 6c30: IO_read_block_alt
+;     reads a block and the following block to a fixed address (0x7e, 0x7f)
+;     param:
+;         A: unknown
+;         X: unknown
+;     return:
+;         none
+;
+
+; list of relevant files that cannot be decrunched
+; PRTY.DATA (britannia)
+; LIST (britannia)
+; SLIST (britannia)
+; TLIST (britannia)
+; ROSTER (britannia)
+; STORY1.TXT (dwelling)
+; STORY2.TXT (dwelling)
+; STORY3.TXT (dwelling)
+; STORY4.TXT (dwelling)
+; BLANK.PRTY (britannia, osi)
+; CREATE1.TXT (osi)
+; M9 (osi)
+
+
+; export the entry points of the functions
+.export _IO_request_disk_id_entry
+.export _IO_request_disk_char_entry
+.export _IO_load_file_entry
+.export _IO_save_file_entry
+.export _IO_read_block_entry
+.export _IO_read_block_alt_entry
+
+.export get_crunched_byte
+.export decrunch_table
+
+; imports
+.import EXO_decrunch
+
+
+.segment "IO_CODE"
+
+    ; --------------------------------------------------------------------
+    _IO_request_disk_id_entry:
+        clc
+        adc #$40   ; add 40 to get the character
+
+    ; --------------------------------------------------------------------
+    _IO_request_disk_char_entry:
+        sta requested_disk
+        clc        ; disk request always succeeds
+        rts
+
+    ; --------------------------------------------------------------------
+    ; IO_load_file_entry: load file
+    ; filename after return address
+    ; x: return mode (0, 1, >1)
+    _IO_load_file_entry:
+        stx requested_loadmode
+
+        ; set fileparameter
+        lda #$08
+        ldx drive_id
+        ldy #$01 
+        jsr kernal_SETLFS
+
+        ; copy name
+        pla
+        sta copy_name_address_low
+        pla
+        sta copy_name_address_high
+        jsr copy_filename ; returns length in A
+
+        ; set filename
+        ldx #<requested_fullname
+        ldy #>requested_fullname
+        jsr kernal_SETNAM  ; A = File name length; X/Y = Pointer to file name.
+
+        ; load
+        jsr $0126  ; sound off
+        lda #$00 
+    :   jsr kernal_LOAD
+        bcc :+     ; no error, continue
+        cmp #$04   ; file not found
+        beq load_return
+        bcs :-     ; repeat on other error
+
+        ; store last loaded address X/Y
+    :   stx copy_address_low
+        sty copy_address_high
+
+        ; close
+        lda #$08
+        jsr kernal_CLOSE
+
+        ; decompress or simply load
+        lda #$80   ; bit 7 set
+        bit requested_loadmode
+        bmi skip_decrunch  ; bit 7 is set: no decrunch
+        lda $ff00  ; for c128 to decrunch we need ram only
+        pha
+        ora #$30   ; set c000-feff to ram
+        sta $ff00
+        ldx #decrunch_buffer_size ; buffer size
+    :   jsr get_crunched_byte
+        dex
+        bne :-
+        jsr EXO_decrunch  ; decrunch
+        pla        ; restore c128 mmu
+        sta $ff00
+    skip_decrunch:
+        jsr $0129  ; sound on
+
+        ; decide how to start the loaded prg
+        lda requested_loadmode
+        and #$7f
+        beq load_success               ; 0: return
+        cmp #$01
+        beq load_jumptomain            ; 1: jump to $800
+        jmp $a700                      ; >1: jump to $a700
+    load_jumptomain:
+        jmp $8000
+    load_success:
+        clc
+    load_return:
+        lda copy_name_address_high    ; return address on stack
+        pha
+        lda copy_name_address_low
+        pha
+        rts
+    requested_loadmode:
+        .byte $00
+
+
+    ; --------------------------------------------------------------------
+    ; IO_save_file_entry
+    ; read parameter from after return address
+    ; string: (after return address) null terminated filename, prepended with "S:"
+    ; word: (after return address) address
+    ; word: (after return address) size
+    _IO_save_file_entry:
+        jsr $0126  ; sound off
+
+        pla                            ; load return address to copy opcode
+        sta copy_name_address_low
+        pla
+        sta copy_name_address_high
+
+        ; skip over "S:"
+        jsr getnext_name_character
+        jsr getnext_name_character
+
+        ; copy filename
+        jsr copy_filename
+        sta $ff    ; length of filename now in ff
+        clc
+        adc #$02
+        ldx #<requested_deletename
+        ldy #>requested_deletename
+        jsr kernal_SETNAM
+
+        ; delete
+        lda #$0f  
+        ldx drive_id
+        ldy #$0f  
+        jsr kernal_SETLFS
+        jsr kernal_OPEN
+        lda #$0f  
+        jsr kernal_CLOSE
+        
+        ; prepare saving
+        lda #$08  
+        ldx drive_id
+        ldy #$00  
+        jsr kernal_SETLFS
+
+        ; set name
+        lda $ff
+        ldx #<requested_fullname
+        ldy #>requested_fullname
+        jsr kernal_SETNAM
+
+        ; save parameter
+        ; copy address and size
+        jsr getnext_name_character  ; address low
+        sta $fe
+        jsr getnext_name_character  ; address high
+        sta $ff
+        jsr getnext_name_character  ; size low
+        sta $fc
+        jsr getnext_name_character  ; size high
+        sta $fd
+    :   clc
+        lda $fe
+        adc $fc
+        tax
+        lda $ff
+        adc $fd
+        tay
+        lda #$fe
+        jsr kernal_SAVE  ; A = Address of zero page w start address; X/Y = End address of memory + 1
+        bcs :-
+        
+        ; close
+        lda #$08  
+        jsr kernal_CLOSE
+        jsr $0129  ; music on
+
+        ; leave
+        lda copy_name_address_high    ; return address on stack
+        pha
+        lda copy_name_address_low
+        pha
+        rts
+
+
+    ; --------------------------------------------------------------------
+    ; meaning of function unclear, copied from temp.subs
+    ; parameter a, x
+    ; some calculations to get the track and number from a
+    _IO_read_block_alt_entry:
+        sta alt_sector
+        sta alt_track
+        txa
+        lsr a
+        ror alt_track
+        lsr alt_track
+        lsr alt_track
+        lda alt_sector
+        and #$07
+        asl a
+        sta alt_sector
+        lda #$7e
+        ldy alt_track
+        ldx alt_sector
+        jsr _IO_read_block_entry
+        lda #$7f
+        ldy alt_track
+        ldx alt_sector
+        inx
+        jmp _IO_read_block_entry
+    alt_track:
+        .byte $00
+    alt_sector:
+        .byte $00
+
+
+    ; --------------------------------------------------------------------
+    ; IO_read_block_entry
+    ; y:track x:sector a:high destination address
+    ; modify track and sector and call original_load_block
+    _IO_read_block_entry:
+        sta $ff    ; save address
+        stx $fe
+        lda requested_disk
+        sec
+        sbc #$41
+        tax
+        
+        ; load track corrections
+        tya
+        clc
+        adc track_corrections, x
+        tay
+
+        ; load sector corrections
+        lda sector_corrections, x
+        clc
+        adc $fe
+        tax
+        lda $ff    ; load address
+
+        ; execute
+        jmp original_load_block
+        ; no rts
+
+    track_corrections:
+        .byte $00
+        .byte britannia_track_correction
+        .byte towne_track_correction
+        .byte dwelling_track_correction
+        .byte castle_track_correction
+        .byte keep_track_correction
+        .byte dungeon_track_correction
+        .byte underworld_track_correction
+
+    sector_corrections:
+        .byte $00
+        .byte britannia_sector_correction
+        .byte towne_sector_correction
+        .byte dwelling_sector_correction
+        .byte castle_sector_correction
+        .byte keep_sector_correction
+        .byte dungeon_sector_correction
+        .byte underworld_sector_correction
+
+
+
+    ; ====================================================================
+    ; loading file utility
+
+    ; --------------------------------------------------------------------
+    ; returns next character in A
+    getnext_name_character:
+    copy_name_address_low = copy_name_address + 1
+    copy_name_address_high = copy_name_address + 2
+        inc copy_name_address_low   ; first increase address
+        bne copy_name_address
+        inc copy_name_address_high
+    copy_name_address:
+        lda $ffff                            ; then load
+        rts
+
+
+    ; --------------------------------------------------------------------
+    ; copies filename to temporary storage
+    ; return length in A
+    copy_filename:
+        ldy #$ff
+    :   iny
+        jsr getnext_name_character     ; next char in A
+        sta requested_filename, y      ; and store
+        bne :-
+        iny       ; additional increase for leading drive letter
+        tya
+        rts
+
+
+    ; --------------------------------------------------------------------
+    ; gets next byte to decrunch, moves backwards
+    ; and processes data through a 8 byte ring buffer
+    ; to comply with safety offset up to 8
+    ; must not change X, Y, C, O
+    ; maximum safety buffer is 6
+    get_crunched_byte:
+        txa
+        pha
+        ; load byte from buffer to temp
+        ldx decrunch_pointer
+        lda decrunch_buffer, x
+        sta decrunch_temp
+        ; decrease pointer to source
+        lda copy_address_low
+        bne :+
+        dec copy_address_high
+    :   dec copy_address_low
+        ; copy byte from source to buffer
+    copy_address_low = * + 1
+    copy_address_high = * + 2
+        lda $ffff               ; load
+        sta decrunch_buffer, x
+        ; inc buffer
+        inc decrunch_pointer
+        lda #(decrunch_buffer_size - 1)  ; buffer size of 8 bytes
+        and decrunch_pointer
+        sta decrunch_pointer
+        ; restore X
+        pla
+        tax
+        lda decrunch_temp
+        rts
+
+;    get_crunched_byte:
+;        lda copy_address_low    ; decrease
+;        bne :+
+;        dec copy_address_high
+;    :   dec copy_address_low
+;        lda decrunch_buffer+5
+;        pha                     ; put old byte on
+;        lda decrunch_buffer+4
+;        sta decrunch_buffer+5
+;        lda decrunch_buffer+3
+;        sta decrunch_buffer+4
+;        lda decrunch_buffer+2
+;        sta decrunch_buffer+3
+;        lda decrunch_buffer+1
+;        sta decrunch_buffer+2
+;        lda decrunch_buffer+0
+;        sta decrunch_buffer+1
+;    copy_address_low = * + 1
+;    copy_address_high = * + 2
+;        lda $ffff               ; load
+;        sta decrunch_buffer
+;        pla                     ; release first byte
+;        rts
+
+
+    ; --------------------------------------------------------------------
+    ; compare filename 
+    ; name address in x,y
+;    compare_filename:
+;        stx $fe
+;        sty $ff
+;
+;        ; compare filename
+;        ldy #$ff
+;        sty $fc  ; 0xff means decrunch necessary
+;    nameloop:
+;        iny
+;        lda #$2a   ; '*'
+;        cmp requested_fullname, y  ; character in name is '*', we have a match
+;        beq namematch
+;        lda requested_fullname, y  ; compare character with character in entry
+;        cmp ($fe), y               ; if not equal nextname
+;        bne nomatch
+;        lda #$0                    ; compare if both character are zero
+;        cmp ($fe), y               ; if not, next name
+;        beq namematch
+;        jmp nameloop
+;    namematch: ; if match we return double, as no decrnch
+;        tsx
+;        dex
+;        dex
+;        txs
+;    nomatch:
+;        rts
+
+
+
+.segment "IO_DATA"
+
+    ; --------------------------------------------------------------------
+    ; variables
+    decrunch_buffer_size = $08
+    decrunch_temp:
+        .byte $00
+    decrunch_pointer:
+        .byte $00
+    decrunch_buffer:
+        .res decrunch_buffer_size, $00
+
+    requested_deletename:
+        .byte $53, $3a  ; "S:"
+    requested_fullname:
+    requested_disk:
+        .byte $41
+    requested_filename:
+        .res 15, $00
+
+    decrunch_table:
+        .res 156, $00
+    
+;    save_files_size_low:
+;        .byte $ff
+;    save_files_size_high:
+;        .byte $ff
+;    save_source_low:
+;        .byte $ff
+;    save_source_high:
+;        .byte $ff
+
+;    name_list:
+;        .byte $42, $4c, $49, $53, $54, $00  ; 'BLIST'
+;    name_slist:
+;        .byte $42, $53, $4c, $49, $53, $54, $00  ; 'BSLIST'
+;    name_utlist:
+;        .byte $48, $54, $4c, $49, $53, $54, $00  ; 'HTLIST'
+;    name_btlist:
+;        .byte $42, $54, $4c, $49, $53, $54, $00  ; 'BTLIST'
+;    name_roster:
+;        .byte $42, $50, $52, $4f, $53, $54, $45, $52, $00  ; 'BROSTER'
+;    name_prtydata:
+;        .byte $42, $50, $52, $54, $59, $2e, $44, $41, $54, $41, $00  ; 'BPRTY.DATA'

--- a/src/backbit/io-replacement.cfg
+++ b/src/backbit/io-replacement.cfg
@@ -1,0 +1,38 @@
+# ----------------------------------------------------------------------------
+# Copyright 2019 Drunella
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+FEATURES {
+    STARTADDRESS:    default = $6c49;
+}
+
+SYMBOLS {
+    __LOADADDR__:    type = import;
+}
+
+MEMORY {
+    LOADADDR: file = %O, start = %S - 2, size = $0002;
+    IGNORE:   file = "", start = $7c00,  size = $0100;
+
+    IO_REPLACEMENT:      start = $6c49,  size = $0265,  fill = yes,  fillval = $00;
+}
+
+SEGMENTS {
+    LOADADDR: load = LOADADDR, type = ro;
+    EXO_CODE: load = IGNORE           type = rw,  start = $7c00;
+
+    IO_CODE:  load = IO_REPLACEMENT,  type = rw;
+    IO_DATA:  load = IO_REPLACEMENT,  type = rw;
+}

--- a/src/backbit/io.i
+++ b/src/backbit/io.i
@@ -1,0 +1,60 @@
+; ----------------------------------------------------------------------------
+; Copyright 2019 Drunella
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+; ----------------------------------------------------------------------------
+
+
+kernal_SETLFS = $ffba
+kernal_SETNAM = $ffbd
+kernal_LOAD   = $ffd5
+kernal_CLOSE  = $ffc3
+kernal_SAVE   = $ffd8
+kernal_OPEN   = $ffc0
+
+;decrunch_table = $7f00
+
+drive_id = $6c33
+original_load_block = $6eae
+
+britannia_track_original = 19
+britannia_track_height = 17
+britannia_track_correction = 22
+britannia_sector_correction = 0
+underworld_track_original = 19
+underworld_track_height = 17
+underworld_track_correction = 22
+underworld_sector_correction = 16
+
+towne_track_original = 24
+towne_track_height = 12
+towne_track_correction = 34
+towne_sector_correction = 0
+dwelling_track_original = 24
+dwelling_track_height = 12
+dwelling_track_correction = 34
+dwelling_sector_correction = 16
+
+castle_track_original = 24
+castle_track_height = 12
+castle_track_correction = 4
+castle_sector_correction = 0
+keep_track_original = 24
+keep_track_height = 12
+keep_track_correction = 4
+keep_sector_correction = 16
+
+dungeon_track_original = 25
+dungeon_track_height = 11
+dungeon_track_correction = $f8  ; -8
+dungeon_sector_correction = 0

--- a/src/backbit/loader.cfg
+++ b/src/backbit/loader.cfg
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+# Copyright 2019 Drunella
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+FEATURES {
+    STARTADDRESS:    default = $2000;
+}
+
+SYMBOLS {
+    __LOADADDR__:    type = import;
+}
+
+MEMORY {
+    LOADADDR: file = %O, start = %S - 2, size = $0002;
+    LOADER:   start = $2000,  size = $1000,  fill = no;
+}
+
+SEGMENTS {
+    LOADADDR: load = LOADADDR, type = ro;
+    LOADER: load = LOADER,  type = rw;
+}

--- a/src/backbit/loader.s
+++ b/src/backbit/loader.s
@@ -1,0 +1,233 @@
+; ----------------------------------------------------------------------------
+; Copyright 2019 Drunella
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+; ----------------------------------------------------------------------------
+
+; code mostly produced by:
+; da65 V2.17 - Git 0576fe51
+; Created:    2019-05-18 00:17:30
+; Input file: build/source/xyzzy.prg
+
+
+.setcpu "6502"
+
+bankin_kernal   = $6C03
+bankout_kernal  = $6C06
+IO_load_file    = $6C24
+init_music      = $720F
+drive_selection = $6c33
+kernal_SCNKEY   = $FF9F
+kernal_SETLFS   = $FFBA
+kernal_SETNAM   = $FFBD
+kernal_OPEN     = $FFC0
+kernal_CLOSE    = $FFC3
+kernal_LOAD     = $FFD5
+kernal_SAVE     = $FFD8
+
+
+.segment "LOADER"
+
+    ; ----------------------------------------------------------------------------
+    loader_entry:
+        ; copied from original
+        lda #$04
+        sta $0289  ; Maximum length of keyboard buffer. Values: 4: buffer size
+        sta $0A20
+        lda #$60
+        sta $0126
+        sta $0129
+        lda #$EB
+        sta $028A  ; Keyboard repeat switch. Bits: 11101011
+        lda #$0E
+        sta $FF00  ; c128 mmu 0b00001110, IO, kernal, RAM0. 48K RAM
+        lda #$00
+        sta $37
+        sta $C8
+        sta $79
+        sta $71
+        sec
+        ror $78
+        lda #$00
+        sta $D020  ; Border Color black
+        ldx #$20   ; Copy IRQ Handler
+    :   lda irq_routine, x
+        sta $0380, x
+        dex
+        bpl :-
+        lda #$9E
+        sta $0318
+        lda #$03
+        sta $0319  ; Execution address of non-maskable interrupt service routine to 039e (single rti)
+        lda #$4C
+        cmp $C024
+        bne skip_c128  ; branch if no C128
+        lda #$80
+        sta $C8
+        sta $79
+        lda #$95
+        sta $0318
+        lda #$00
+        sta $00
+        sta $9D    ; c128: I/O messages: 192 = all, 128 = commands, 64 = errors, 0 = nil
+        lda #$FF
+        sta $D8    ; c128 Graphics mode code
+        lda #$0B
+        sta $D011  ; VIC Control Register 1
+    skip_c128:
+        lda #$06
+        sta $01    ; memory mapping 0b00000110, io visible, no basic, kernal
+        lda $C8
+        bpl load_c64
+        jmp load_c128
+
+    load_c64:
+        sei
+        lda #$83
+        sta $0302
+        lda #$A4
+        sta $0303
+        lda #$48
+        sta $028F
+        lda #$EB
+        sta $0290
+        ; lda #$A5
+        ; sta $0330
+        ; lda #$F4
+        ; sta $0331
+        cli
+        ; drive selection removed
+        ldx #<name_UJ
+        ldy #>name_UJ
+        lda #$02
+        jsr kernal_SETNAM
+        lda #$0F
+        tay
+        ldx $ba    ; use last used drive
+        jsr kernal_SETLFS
+        jsr kernal_OPEN
+        ldx #$11   ; wait
+    ; :   lda #$FF
+        ; sec
+    ; :   pha
+    ; :   sbc #$01
+        ;     bne :-
+        ;     pla
+        ;     sbc #$01
+        ;     bne :--
+        ;     dex
+        ;     bne :---
+        lda #$0F
+        jsr kernal_CLOSE
+
+    load_c128:
+        lda $C8
+        bpl skip_m
+        lda #$01   ; load m.prg
+        ldx #<name_M
+        ldy #>name_M
+        jsr set_fileparams
+        lda #$00
+        jsr kernal_LOAD
+        jsr init_music
+        lda #$04   ; load subs.128.prg
+        ldx #<name_SUBS128
+        ldy #>name_SUBS128
+        jsr set_fileparams
+        lda #$00
+        jsr kernal_LOAD
+        lda $D5
+        jmp :+
+
+    skip_m:
+        lda #$80
+        sta $FFFE
+        lda #$03
+        sta $FFFF
+        cli
+        lda $C5
+    :   pha
+
+        ; load exo
+        lda #$03
+        ldx #<name_EXO
+        ldy #>name_EXO
+        jsr set_fileparams
+        lda #$00
+        jsr kernal_LOAD
+
+        ; load temp.subs
+        lda #$05
+        ldx #<name_TEMPSUBS
+        ldy #>name_TEMPSUBS
+        jsr set_fileparams
+        lda #$00
+        jsr kernal_LOAD
+        lda $ba    ; store drive_selection in temp.subs
+        sta drive_selection
+        pla
+        cmp #$22
+        bne normal_startup
+        ldx #$01
+        jsr IO_load_file
+        .byte $51,$53,$00  ; QS for quickstart
+
+    normal_startup:
+        ldx #$00
+        jsr IO_load_file
+        .byte $53,$54,$2A,$00  ; ST* for startup
+        jmp $8000
+
+    ; ----------------------------------------------------------------------------
+    ; A = File name length; X/Y = Pointer to file name.
+    set_fileparams:
+        jsr kernal_SETNAM
+        lda #$08
+        ldx $ba    ; read drive from last used drive
+        ldy #$01
+        jmp kernal_SETLFS
+
+    ; ----------------------------------------------------------------------------
+    name_UJ:
+        .byte $55,$4A,$00  ; 'UJ'
+    name_TEMPSUBS:
+        .byte $54,$45,$4D,$50,$2A  ; 'TEMP*'
+    name_M: 
+        .byte $4D  ; 'M'
+    name_SUBS128:
+        .byte $53,$55,$42,$2A ; 'SUB*'
+    name_EXO:
+        .byte $45, $58, $4f  ; 'EXO'
+
+    ; ----------------------------------------------------------------------------
+    irq_routine:
+        pha
+        txa
+        pha
+        tya
+        pha
+        lda $FF00
+        pha
+        jsr bankin_kernal
+        jsr kernal_SCNKEY
+        lda $DC0D
+        jsr bankout_kernal
+        pla
+        sta $FF00
+        pla
+        tay
+        pla
+        tax
+        pla
+        rti
+


### PR DESCRIPTION
Would be great to add support for BackBit to the main archive!

I'm interested in getting music to work as well. Is there a way to remove exomizer decompression since it's not needed for speed and put music in the BackBit version (derived from the D81)?